### PR TITLE
Skeleton Dockerfile & `docker-compose` for containerized setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ruby:3.2
+
+ENV BUNDLER_VERSION=2.4.6
+
+RUN apt-get update -qq
+RUN apt-get install -y \
+
+  # Buildchain Essentials
+  build-essential \
+  libvips
+
+RUN gem install bundler
+
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+
+RUN bundle install
+
+COPY . ./
+
+ENTRYPOINT ["./entrypoints/docker-entrypoint.sh"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.2-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
@@ -215,6 +217,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.0-aarch64-linux)
     sqlite3 (1.6.0-arm64-darwin)
     sqlite3 (1.6.0-x86_64-linux)
     thor (1.2.1)
@@ -257,6 +260,8 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  aarch64-linux
+  aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-22
   x86_64-linux

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.4'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+      - gem_cache:/usr/local/bundle/gems
+    env_file: .env
+    environment:
+      RAILS_ENV: development
+
+volumes:
+  gem_cache:

--- a/entrypoints/docker-entrypoint.sh
+++ b/entrypoints/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+bundle exec rails s -b 0.0.0.0


### PR DESCRIPTION
* Adding a Dockerfile helps with onboarding & experimenting with the template & app repo, so that people can try out passkeys more quickly