### PR TITLE
Ignore .ruby-gemset for RVM users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@
 .DS_Store
 
 .env
+
+# Ignore RVM gemset file
+.ruby-gemset


### PR DESCRIPTION
### Goal of this PR
Add .ruby-gemset to .gitignore, so RVM users don't see it as changed