### PR TITLE
Submit form data to newChallengeURL

### DIFF
--- a/app/javascript/session_form.js
+++ b/app/javascript/session_form.js
@@ -17,6 +17,7 @@ let getChallengeAndSubmitCredential = async function(form){
   const csrfToken = document.getElementsByName("csrf-token")[0].content;
   let credentialFieldName = form.dataset.credentialFieldName
   let newChallengeURL = new URL(form.dataset.challengeUrl)
+  let data = new FormData(form)
 
   let challengeFetch = fetch(newChallengeURL, {
     method: "POST",
@@ -24,6 +25,7 @@ let getChallengeAndSubmitCredential = async function(form){
       "Accept": "application/json",
       "X-CSRF-Token": csrfToken,
     },
+    body: data
   })
 
   const challengeJSON = await(await challengeFetch).json()


### PR DESCRIPTION
### Context
Android phones need allowCredentials during sign in flow to find the site passkeys.
Fixes: https://github.com/ruby-passkeys/devise-passkeys-template/issues/12

### devise-passkeys gem
This PR works with `android_phone/sign_in` branch: https://github.com/heliocola/devise-passkeys/tree/android_phone/sign_in
Gemfile should be changed to:
```
  gem "devise-passkeys", git: 'https://github.com/heliocola/devise-passkeys.git', branch: 'android_phone/sign_in'
```
